### PR TITLE
feat: add self-hosted Umami analytics

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,6 +4,16 @@ template:
   bootstrap: 5
   params:
     ganalytics: UA-138721086-1
+  includes:
+    in_header: |
+      <script
+        defer
+        src="https://ca-umami-prod.lemonglacier-6a5930b7.uksouth.azurecontainerapps.io/script.js"
+        data-website-id="0b91ce54-0c0c-4906-89c6-312165ce001b"
+        data-domains="martinctc.github.io"
+        data-do-not-track="true"
+        data-exclude-search="true"
+        data-exclude-hash="true"></script>
 
 navbar:
   structure:


### PR DESCRIPTION
Adds the self-hosted [Umami](https://umami.is/) tracker to the pkgdown site, using its own website ID (`0b91ce54`).

## Changes

- `_pkgdown.yml`: adds `template.includes.in_header`. Existing `bootstrap` and `params` settings are preserved.

Privacy defaults applied: `data-domains="martinctc.github.io"` (so local builds send nothing), `data-do-not-track`, `data-exclude-search`, and `data-exclude-hash`. Umami is cookieless; the website ID is an identifier, not a credential.

## Note

`template.params.ganalytics` is still set to `UA-138721086-1`. Universal Analytics stopped processing data in July 2023, so that tag has collected nothing for over two years and is now dead weight. Left in place deliberately — happy to remove it in a follow-up.